### PR TITLE
Small README correction around desktop builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ FocusBloom is a Kotlin Multiplatform app that helps users enhance their producti
 <img src="art/dsk_screen3.png"/>
 
 ## Architecture
-The app is shared between Android, iOS and Desktop. The shared code is written in Kotlin and the UI is built with Compose Multiplatform. Shared code, written in Kotlin, is compiled to JVM bytecode for Android with Kotlin/JVM and to native binaries for iOS and Desktop with Kotlin/Native.
+The app is shared between Android, iOS and Desktop. The shared code is written in Kotlin and the UI is built with Compose Multiplatform. Shared code, written in Kotlin, is compiled to JVM bytecode for Android and Desktop with Kotlin/JVM and to native binaries for iOS with Kotlin/Native.
 ### Modules
 - shared:
   - contains all the shared code between the platforms


### PR DESCRIPTION
Compose Desktop - for now - is also built using the JVM, then wrapped in a "native distribution" (i.e. the final packages to install). That's why we use Java libraries within the desktop sources.

There are some efforts to also make it use Kotlin/Native (with some experimental work already done for macOS), but it's still far from ready, and not a high priority thing for now.

This commit corrects that part.