### PR TITLE
Harden release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,14 @@ name: Build
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 concurrency:
   group: build-${{ github.ref }}
@@ -15,6 +21,7 @@ jobs:
   build:
     name: 🔨 Build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,15 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - 'v*.*.*'
 
 defaults:
   run:
     shell: bash
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release_desktop:
@@ -17,7 +21,8 @@ jobs:
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
-    if: startsWith(github.ref, 'refs/tags/')
+    timeout-minutes: 30
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'joelkanyi/FocusBloom'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -80,7 +85,8 @@ jobs:
   release_android:
     name: Release Android App
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    timeout-minutes: 25
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'joelkanyi/FocusBloom'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -120,7 +126,8 @@ jobs:
   changelog:
     name: Changelog
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    timeout-minutes: 15
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'joelkanyi/FocusBloom'
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Release fired the full macOS + Windows + Linux matrix on ANY tag push (bare `- '*'`), with no timeouts or concurrency guard.

- Scope the trigger to real release tags (`v*.*.*`).
- Add `timeout-minutes` to every release job (the macOS desktop leg is the costly one).
- Add a `concurrency` group so a re-tag cancels the superseded matrix.
- Add `if: github.repository == 'joelkanyi/FocusBloom'` guard to the release jobs.
- Add build-job timeout and docs `paths-ignore`.